### PR TITLE
hub.py should reference extensions["mercure_sse"]

### DIFF
--- a/flask_mercure_sse/hub.py
+++ b/flask_mercure_sse/hub.py
@@ -45,12 +45,12 @@ def subscribe():
     topics = request.args.getlist("topic")
     claim = get_authorization_jwt("subscriber_secret_key")
 
-    if not current_app.extensions["mercure"].hub_allow_anonymous and not claim:
+    if not current_app.extensions["mercure_sse"].hub_allow_anonymous and not claim:
         abort(403)
 
     @stream_with_context
     def stream():
-        sub = current_app.extensions["mercure"].broker.subscribe(topics, claim.get("subscribe", []) if claim else [])
+        sub = current_app.extensions["mercure_sse"].broker.subscribe(topics, claim.get("subscribe", []) if claim else [])
         while True:
             yield sub.get()
             
@@ -59,7 +59,7 @@ def subscribe():
 
 @hub_blueprint.post("")
 def publish():
-    if not current_app.extensions["mercure"].hub_allow_publish:
+    if not current_app.extensions["mercure_sse"].hub_allow_publish:
         abort(405)
 
     claim = get_authorization_jwt("publisher_secret_key")
@@ -77,7 +77,7 @@ def publish():
     if not allowed:
         abort(403)
 
-    return current_app.extensions["mercure"].broker.publish(
+    return current_app.extensions["mercure_sse"].broker.publish(
         topic,
         request.form["data"],
         private=request.form.get("private"),
@@ -89,7 +89,7 @@ def publish():
 
 def get_authorization_jwt(key):
     auth_value = None
-    cookie_name = current_app.extensions["mercure"].authz_cookie_name
+    cookie_name = current_app.extensions["mercure_sse"].authz_cookie_name
     if request.headers.get("Authorization"):
         auth_value = request.headers["Authorization"].split(" ")[1]
     elif request.cookies.get(cookie_name):
@@ -99,7 +99,7 @@ def get_authorization_jwt(key):
     elif session.get("mercure"):
         return session["mercure"]
     if auth_value:
-        return jwt.decode(auth_value, getattr(current_app.extensions["mercure"], key), ["HS256"]).get("mercure", {})
+        return jwt.decode(auth_value, getattr(current_app.extensions["mercure_sse"], key), ["HS256"]).get("mercure", {})
     
 
 def match_topic_selector(selector, topic):


### PR DESCRIPTION
The dev hub uses `current.app.extensions["mercure"]`, but the extension has key of `mercure_sse`